### PR TITLE
Add in-memory SSH private key and known hosts support

### DIFF
--- a/src/auth.zig
+++ b/src/auth.zig
@@ -256,6 +256,16 @@ test "optionsInit" {
     o.deinit();
 }
 
+test "optionsInitWithPrivateKey" {
+    const o = try Options.init(
+        std.testing.allocator,
+        .{ .private_key = "test-key-data" },
+    );
+    defer o.deinit();
+
+    try std.testing.expectEqualStrings("test-key-data", o.private_key.?);
+}
+
 /// Processes the "searchable buf" for in session auth by checking if any of the auth patterns
 /// show up.
 pub fn processSearchableAuthBuf(

--- a/src/auth.zig
+++ b/src/auth.zig
@@ -88,6 +88,7 @@ pub const LookupKeyValue = struct {
 pub const OptionsInputs = struct {
     username: ?[]const u8 = null,
     password: ?[]const u8 = null,
+    private_key: ?[]const u8 = null,
     private_key_path: ?[]const u8 = null,
     private_key_passphrase: ?[]const u8 = null,
     // for now(? forever?) lookups are limited to 16 times. adding a lookup callback in the future
@@ -115,6 +116,7 @@ pub const Options = struct {
     allocator: std.mem.Allocator,
     username: ?[]const u8,
     password: ?[]const u8,
+    private_key: ?[]const u8,
     private_key_path: ?[]const u8,
     private_key_passphrase: ?[]const u8,
     lookups: LookupItems,
@@ -133,6 +135,7 @@ pub const Options = struct {
             .allocator = allocator,
             .username = opts.username,
             .password = opts.password,
+            .private_key = opts.private_key,
             .private_key_path = opts.private_key_path,
             .private_key_passphrase = opts.private_key_passphrase,
             .lookups = try opts.lookups.cloneOwned(allocator),
@@ -146,6 +149,10 @@ pub const Options = struct {
 
         if (o.password != null) {
             o.password = try o.allocator.dupe(u8, o.password.?);
+        }
+
+        if (o.private_key != null) {
+            o.private_key = try o.allocator.dupe(u8, o.private_key.?);
         }
 
         if (o.private_key_path != null) {
@@ -179,6 +186,10 @@ pub const Options = struct {
 
         if (self.password != null) {
             self.allocator.free(self.password.?);
+        }
+
+        if (self.private_key != null) {
+            self.allocator.free(self.private_key.?);
         }
 
         if (self.private_key_path != null) {

--- a/src/ffi-options.zig
+++ b/src/ffi-options.zig
@@ -94,6 +94,8 @@ pub const FFIOptions = extern struct {
         username_len: usize = 0,
         password: [*c]const u8 = undefined,
         password_len: usize = 0,
+        private_key: [*c]const u8 = undefined,
+        private_key_len: usize = 0,
         private_key_path: [*c]const u8 = undefined,
         private_key_path_len: usize = 0,
         private_key_passphrase: [*c]const u8 = undefined,
@@ -125,6 +127,8 @@ pub const FFIOptions = extern struct {
             override_open_args_len: usize = 0,
             ssh_config_path: [*c]const u8 = undefined,
             ssh_config_path_len: usize = 0,
+            known_hosts: [*c]const u8 = undefined,
+            known_hosts_len: usize = 0,
             known_hosts_path: [*c]const u8 = undefined,
             known_hosts_path_len: usize = 0,
             enable_strict_key: ?*bool = null,
@@ -132,6 +136,8 @@ pub const FFIOptions = extern struct {
             term_width: ?*u16 = null,
         },
         ssh2: extern struct {
+            known_hosts: [*c]const u8 = undefined,
+            known_hosts_len: usize = 0,
             known_hosts_path: [*c]const u8 = undefined,
             known_hosts_path_len: usize = 0,
             libssh2trace: ?*bool = null,
@@ -164,6 +170,10 @@ pub const FFIOptions = extern struct {
 
         if (self.auth.password_len > 0) {
             o.password = self.auth.password[0..self.auth.password_len];
+        }
+
+        if (self.auth.private_key_len > 0) {
+            o.private_key = self.auth.private_key[0..self.auth.private_key_len];
         }
 
         if (self.auth.private_key_path_len > 0) {
@@ -274,6 +284,10 @@ pub const FFIOptions = extern struct {
                     o.bin.ssh_config_path = self.transport.bin.ssh_config_path[0..self.transport.bin.ssh_config_path_len];
                 }
 
+                if (self.transport.bin.known_hosts_len > 0) {
+                    o.bin.known_hosts = self.transport.bin.known_hosts[0..self.transport.bin.known_hosts_len];
+                }
+
                 if (self.transport.bin.known_hosts_path_len > 0) {
                     o.bin.known_hosts_path = self.transport.bin.known_hosts_path[0..self.transport.bin.known_hosts_path_len];
                 }
@@ -296,6 +310,10 @@ pub const FFIOptions = extern struct {
                 var o = transport.OptionsInputs{
                     .ssh2 = .{},
                 };
+
+                if (self.transport.ssh2.known_hosts_len > 0) {
+                    o.ssh2.known_hosts = self.transport.ssh2.known_hosts[0..self.transport.ssh2.known_hosts_len];
+                }
 
                 if (self.transport.ssh2.known_hosts_path_len > 0) {
                     o.ssh2.known_hosts_path = self.transport.ssh2.known_hosts_path[0..self.transport.ssh2.known_hosts_path_len];

--- a/src/transport-bin.zig
+++ b/src/transport-bin.zig
@@ -744,3 +744,13 @@ test "transportInit" {
     t.deinit();
     o.deinit();
 }
+
+test "optionsInitWithKnownHosts" {
+    const o = try Options.init(
+        std.testing.allocator,
+        .{ .known_hosts = "host1 ssh-rsa AAAA..." },
+    );
+    defer o.deinit();
+
+    try std.testing.expectEqualStrings("host1 ssh-rsa AAAA...", o.known_hosts.?);
+}

--- a/src/transport-bin.zig
+++ b/src/transport-bin.zig
@@ -34,6 +34,7 @@ pub const OptionsInputs = struct {
     override_open_args: ?[]const u8 = null,
 
     ssh_config_path: ?[]const u8 = null,
+    known_hosts: ?[]const u8 = null,
     known_hosts_path: ?[]const u8 = null,
 
     enable_strict_key: bool = false,
@@ -51,6 +52,7 @@ pub const Options = struct {
     extra_open_args: ?[]const u8,
     override_open_args: ?[]const u8,
     ssh_config_path: ?[]const u8,
+    known_hosts: ?[]const u8,
     known_hosts_path: ?[]const u8,
     enable_strict_key: bool,
     term_height: u16,
@@ -68,6 +70,7 @@ pub const Options = struct {
             .extra_open_args = opts.extra_open_args,
             .override_open_args = opts.override_open_args,
             .ssh_config_path = opts.ssh_config_path,
+            .known_hosts = opts.known_hosts,
             .known_hosts_path = opts.known_hosts_path,
             .enable_strict_key = opts.enable_strict_key,
             .term_height = opts.term_height,
@@ -89,6 +92,10 @@ pub const Options = struct {
 
         if (o.ssh_config_path != null) {
             o.ssh_config_path = try o.allocator.dupe(u8, o.ssh_config_path.?);
+        }
+
+        if (o.known_hosts != null) {
+            o.known_hosts = try o.allocator.dupe(u8, o.known_hosts.?);
         }
 
         if (o.known_hosts_path != null) {
@@ -114,6 +121,10 @@ pub const Options = struct {
 
         if (self.ssh_config_path != null) {
             self.allocator.free(self.ssh_config_path.?);
+        }
+
+        if (self.known_hosts != null) {
+            self.allocator.free(self.known_hosts.?);
         }
 
         if (self.known_hosts_path != null) {

--- a/src/transport-ssh2.zig
+++ b/src/transport-ssh2.zig
@@ -2084,3 +2084,16 @@ test "transportInit" {
     t.deinit();
     o.deinit();
 }
+
+test "optionsInitWithKnownHosts" {
+    const o = try Options.init(
+        std.testing.allocator,
+        .{ .known_hosts = "host1 ssh-rsa AAAA...\nhost2 ssh-ed25519 AAAA..." },
+    );
+    defer o.deinit();
+
+    try std.testing.expectEqualStrings(
+        "host1 ssh-rsa AAAA...\nhost2 ssh-ed25519 AAAA...",
+        o.known_hosts.?,
+    );
+}

--- a/src/transport-ssh2.zig
+++ b/src/transport-ssh2.zig
@@ -465,6 +465,7 @@ pub const ProxyJumpOptions = struct {
 
 /// Holds option inputs for the ssh2 transport.
 pub const OptionsInputs = struct {
+    known_hosts: ?[]const u8 = null,
     known_hosts_path: ?[]const u8 = null,
     libssh2_trace: bool = false,
     netconf: bool = false,
@@ -474,6 +475,7 @@ pub const OptionsInputs = struct {
 /// Holds ssh2 transport options.
 pub const Options = struct {
     allocator: std.mem.Allocator,
+    known_hosts: ?[]const u8,
     known_hosts_path: ?[]const u8,
     libssh2_trace: bool,
     netconf: bool,
@@ -486,6 +488,7 @@ pub const Options = struct {
 
         o.* = Options{
             .allocator = allocator,
+            .known_hosts = opts.known_hosts,
             .known_hosts_path = opts.known_hosts_path,
             .libssh2_trace = opts.libssh2_trace,
             .netconf = opts.netconf,
@@ -814,19 +817,12 @@ pub const Transport = struct {
     ) !void {
         self.log.debug("ssh2.Transport initKnownHost requested", .{});
 
-        if (self.options.known_hosts_path == null) {
+        if (self.options.known_hosts_path == null and self.options.known_hosts == null) {
             return;
         }
 
         const _host = try self.allocator.dupeSentinel(u8, host, 0);
         defer self.allocator.free(_host);
-
-        const _known_hosts_path = try self.allocator.dupeSentinel(
-            u8,
-            self.options.known_hosts_path.?,
-            0,
-        );
-        defer self.allocator.free(_known_hosts_path);
 
         const nh = c.libssh2_knownhost_init(self.initial_session.?);
         if (nh == null) {
@@ -840,19 +836,30 @@ pub const Transport = struct {
         }
         defer c.libssh2_knownhost_free(nh);
 
-        const read_rc = c.libssh2_knownhost_readfile(
-            nh,
-            _known_hosts_path,
-            c.LIBSSH2_KNOWNHOST_FILE_OPENSSH,
-        );
-        if (read_rc < 0) {
-            return errors.wrapCriticalError(
-                errors.ScrapliError.Transport,
-                @src(),
-                self.log,
-                "ssh2.Transport initKnownHost: failed to read known hosts file",
-                .{},
+        if (self.options.known_hosts) |known_hosts_content| {
+            try self.readKnownHostsFromMemory(nh.?, known_hosts_content);
+        } else {
+            const _known_hosts_path = try self.allocator.dupeSentinel(
+                u8,
+                self.options.known_hosts_path.?,
+                0,
             );
+            defer self.allocator.free(_known_hosts_path);
+
+            const read_rc = c.libssh2_knownhost_readfile(
+                nh,
+                _known_hosts_path,
+                c.LIBSSH2_KNOWNHOST_FILE_OPENSSH,
+            );
+            if (read_rc < 0) {
+                return errors.wrapCriticalError(
+                    errors.ScrapliError.Transport,
+                    @src(),
+                    self.log,
+                    "ssh2.Transport initKnownHost: failed to read known hosts file",
+                    .{},
+                );
+            }
         }
 
         var len: usize = 0;
@@ -928,6 +935,63 @@ pub const Transport = struct {
         }
     }
 
+    fn readKnownHostsFromMemory(
+        self: *Transport,
+        nh: *c.LIBSSH2_KNOWNHOSTS,
+        content: []const u8,
+    ) !void {
+        var start: usize = 0;
+
+        for (content, 0..) |byte, i| {
+            if (byte == '\n') {
+                const line = content[start..i];
+                start = i + 1;
+
+                if (line.len == 0 or line[0] == '#') {
+                    continue;
+                }
+
+                const rc = c.libssh2_knownhost_readline(
+                    nh,
+                    @ptrCast(line.ptr),
+                    line.len,
+                    c.LIBSSH2_KNOWNHOST_FILE_OPENSSH,
+                );
+                if (rc < 0) {
+                    return errors.wrapCriticalError(
+                        errors.ScrapliError.Transport,
+                        @src(),
+                        self.log,
+                        "ssh2.Transport readKnownHostsFromMemory: failed to parse known hosts line",
+                        .{},
+                    );
+                }
+            }
+        }
+
+        if (start < content.len) {
+            const line = content[start..];
+
+            if (line.len > 0 and line[0] != '#') {
+                const rc = c.libssh2_knownhost_readline(
+                    nh,
+                    @ptrCast(line.ptr),
+                    line.len,
+                    c.LIBSSH2_KNOWNHOST_FILE_OPENSSH,
+                );
+                if (rc < 0) {
+                    return errors.wrapCriticalError(
+                        errors.ScrapliError.Transport,
+                        @src(),
+                        self.log,
+                        "ssh2.Transport readKnownHostsFromMemory: failed to parse known hosts line",
+                        .{},
+                    );
+                }
+            }
+        }
+    }
+
     fn authenticate(
         self: *Transport,
         start_time: std.Io.Timestamp,
@@ -937,6 +1001,27 @@ pub const Transport = struct {
         auth_options: *auth.Options,
     ) !void {
         self.log.debug("ssh2.Transport authenticate requested", .{});
+
+        if (auth_options.private_key != null) {
+            self.handlePrivateKeyMemoryAuth(
+                start_time,
+                cancel,
+                operation_timeout_ns,
+                session,
+                auth_options,
+            ) catch blk: {
+                break :blk;
+            };
+
+            if (try self.isAuthenticated(
+                start_time,
+                cancel,
+                operation_timeout_ns,
+                session,
+            )) {
+                return;
+            }
+        }
 
         if (auth_options.private_key_path != null) {
             self.handlePrivateKeyAuth(
@@ -1153,6 +1238,99 @@ pub const Transport = struct {
                 @src(),
                 self.log,
                 "ssh2.Transport handlePrivateKeyAuth: failed private key authentication " ++
+                    "error code {d}",
+                .{rc},
+            );
+        }
+    }
+
+    fn handlePrivateKeyMemoryAuth(
+        self: *Transport,
+        start_time: std.Io.Timestamp,
+        cancel: ?*bool,
+        operation_timeout_ns: u64,
+        session: *c.LIBSSH2_SESSION,
+        auth_options: *auth.Options,
+    ) !void {
+        const private_key_passphrase_c = try self.allocator.dupeSentinel(
+            u8,
+            try auth_options.resolveAuthValue(
+                auth_options.private_key_passphrase orelse "",
+            ),
+            0,
+        );
+        defer self.allocator.free(private_key_passphrase_c);
+
+        while (true) {
+            if (cancel != null and cancel.?.*) {
+                return errors.wrapCriticalError(
+                    errors.ScrapliError.Cancelled,
+                    @src(),
+                    self.log,
+                    "ssh2.Transport handlePrivateKeyMemoryAuth: operation cancelled",
+                    .{},
+                );
+            }
+
+            if (operation_timeout_ns != 0 and start_time.untilNow(self.io, .awake).nanoseconds > operation_timeout_ns) {
+                return errors.wrapCriticalError(
+                    errors.ScrapliError.TimeoutExceeded,
+                    @src(),
+                    self.log,
+                    "ssh2.Transport handlePrivateKeyMemoryAuth: operation timeout exceeded",
+                    .{},
+                );
+            }
+
+            const private_key = auth_options.private_key.?;
+
+            const rc = c.libssh2_userauth_publickey_frommemory(
+                session,
+                @ptrCast(@constCast(auth_options.username.?)),
+                auth_options.username.?.len,
+                null,
+                0,
+                @ptrCast(private_key.ptr),
+                private_key.len,
+                private_key_passphrase_c.ptr,
+            );
+
+            if (rc == 0) {
+                break;
+            } else if (rc == c.LIBSSH2_ERROR_EAGAIN) {
+                try std.Io.Clock.Duration.sleep(
+                    .{
+                        .clock = .awake,
+                        .raw = .fromNanoseconds(default_eagain_delay_ns),
+                    },
+                    self.io,
+                );
+
+                continue;
+            }
+
+            var errmsg: [*c]u8 = null;
+            var errlen: c_int = 0;
+
+            const err: c_int = c.libssh2_session_last_error(
+                session,
+                &errmsg,
+                &errlen,
+                0,
+            );
+
+            if (errmsg != null and errlen > 0) {
+                const msg_slice = errmsg[0..@intCast(errlen)];
+                std.debug.print("libssh2 error: {} {s}\n", .{ err, msg_slice });
+            } else {
+                std.debug.print("libssh2 error: {} (no message)\n", .{err});
+            }
+
+            return errors.wrapCriticalError(
+                errors.ScrapliError.Transport,
+                @src(),
+                self.log,
+                "ssh2.Transport handlePrivateKeyMemoryAuth: failed private key authentication " ++
                     "error code {d}",
                 .{rc},
             );


### PR DESCRIPTION
## Summary

- **In-memory SSH private key authentication**: Added a `private_key` field alongside the existing `private_key_path`, enabling authentication via `libssh2_userauth_publickey_frommemory`. This allows callers to provide PEM/OpenSSH key material directly without writing to disk — useful for secrets managers, vault integrations, and containerized environments.
- **In-memory known hosts verification**: Added a `known_hosts` field (alongside `known_hosts_path`) for both the ssh2 and bin transports. For ssh2, known hosts content is parsed line-by-line via `libssh2_knownhost_readline`, keeping strict host key checking functional without a file on disk.
- **Nix flake**: Includes a development flake with zig-overlay pinned to the 0.16.0-dev toolchain for reproducible builds.

## Motivation

When running in ephemeral or locked-down environments (containers, CI, serverless), writing SSH keys and known_hosts to the filesystem is awkward and sometimes impossible. Accepting these values as in-memory byte slices removes that friction while keeping the existing file-path options fully backward compatible.

## Changes

| File | What changed |
|---|---|
| `src/auth.zig` | New `private_key` field on `OptionsInputs` and `Options`, with alloc/free lifecycle |
| `src/transport-ssh2.zig` | New `known_hosts` field, `readKnownHostsFromMemory` parser, `handlePrivateKeyMemoryAuth` using `libssh2_userauth_publickey_frommemory`, auth order updated to try in-memory key first |
| `src/transport-bin.zig` | New `known_hosts` field on `OptionsInputs` and `Options` |
| `src/ffi-options.zig` | FFI structs extended with `private_key`, `known_hosts` fields and length pairs |
| `flake.nix`, `flake.lock` | Nix dev shell with zig 0.16.0-dev via zig-overlay |

## Test plan

- [ ] Verify existing file-path-based authentication and known hosts still work unchanged
- [ ] Test in-memory private key auth with PEM and OpenSSH format keys
- [ ] Test in-memory known hosts with single and multi-line content
- [ ] Confirm FFI bindings expose the new fields correctly