### PR TITLE
Add in-memory private key authentication support for SSH2 transport

### DIFF
--- a/src/auth.zig
+++ b/src/auth.zig
@@ -90,6 +90,7 @@ pub const OptionsInputs = struct {
     password: ?[]const u8 = null,
     private_key_path: ?[]const u8 = null,
     private_key_passphrase: ?[]const u8 = null,
+    private_key_content: ?[]const u8 = null,
     // for now(? forever?) lookups are limited to 16 times. adding a lookup callback in the future
     // would be next step i think, but for now this should be more than ok and the fixed size and
     // the count indicator makes this very easy to work with on the ffi bits.
@@ -117,6 +118,7 @@ pub const Options = struct {
     password: ?[]const u8,
     private_key_path: ?[]const u8,
     private_key_passphrase: ?[]const u8,
+    private_key_content: ?[]const u8,
     lookups: LookupItems,
     force_in_session_auth: bool,
     bypass_in_session_auth: bool,
@@ -135,6 +137,7 @@ pub const Options = struct {
             .password = opts.password,
             .private_key_path = opts.private_key_path,
             .private_key_passphrase = opts.private_key_passphrase,
+            .private_key_content = opts.private_key_content,
             .lookups = try opts.lookups.cloneOwned(allocator),
             .force_in_session_auth = opts.force_in_session_auth,
             .bypass_in_session_auth = opts.bypass_in_session_auth,
@@ -154,6 +157,10 @@ pub const Options = struct {
 
         if (o.private_key_passphrase != null) {
             o.private_key_passphrase = try o.allocator.dupe(u8, o.private_key_passphrase.?);
+        }
+
+        if (o.private_key_content != null) {
+            o.private_key_content = try o.allocator.dupe(u8, o.private_key_content.?);
         }
 
         if (opts.username_pattern) |p| {
@@ -187,6 +194,10 @@ pub const Options = struct {
 
         if (self.private_key_passphrase != null) {
             self.allocator.free(self.private_key_passphrase.?);
+        }
+
+        if (self.private_key_content != null) {
+            self.allocator.free(self.private_key_content.?);
         }
 
         self.lookups.deinitOwned(self.allocator);

--- a/src/ffi-options.zig
+++ b/src/ffi-options.zig
@@ -99,6 +99,8 @@ pub const FFIOptions = extern struct {
         private_key_path_len: usize = 0,
         private_key_passphrase: [*c]const u8 = undefined,
         private_key_passphrase_len: usize = 0,
+        private_key_content: [*c]const u8 = undefined,
+        private_key_content_len: usize = 0,
         lookups: extern struct {
             keys: [*c][*c]const u8 = undefined,
             key_lens: [*c]u16 = undefined,
@@ -173,6 +175,10 @@ pub const FFIOptions = extern struct {
 
         if (self.auth.private_key_passphrase_len > 0) {
             o.private_key_passphrase = self.auth.private_key_passphrase[0..self.auth.private_key_passphrase_len];
+        }
+
+        if (self.auth.private_key_content_len > 0) {
+            o.private_key_content = self.auth.private_key_content[0..self.auth.private_key_content_len];
         }
 
         for (0..self.auth.lookups.count) |idx| {
@@ -577,6 +583,7 @@ const ffi_options_auth_args_json_ish_placeholder =
     \\    "password": "{s}",
     \\    "private_key_path": "{s}",
     \\    "private_key_passphrase": "{s}",
+    \\    "private_key_content": "{s}",
     \\    "force_in_session_auth": {any},
     \\    "bypass_in_session_auth": {any},
     \\    "username_pattern": "{s}",
@@ -594,6 +601,7 @@ fn ffiOptionsAuthToJSON(allocator: std.mem.Allocator, o: *const FFIOptions) ![]u
             cStr(o.auth.password, o.auth.password_len),
             cStr(o.auth.private_key_path, o.auth.private_key_path_len),
             cStr(o.auth.private_key_passphrase, o.auth.private_key_passphrase_len),
+            cStr(o.auth.private_key_content, o.auth.private_key_content_len),
             optBool(o.auth.force_in_session_auth),
             optBool(o.auth.bypass_in_session_auth),
             cStr(o.auth.username_pattern, o.auth.username_pattern_len),

--- a/src/transport-ssh2.zig
+++ b/src/transport-ssh2.zig
@@ -938,7 +938,27 @@ pub const Transport = struct {
     ) !void {
         self.log.debug("ssh2.Transport authenticate requested", .{});
 
-        if (auth_options.private_key_path != null) {
+        if (auth_options.private_key_content != null) {
+            self.handlePrivateKeyContentAuth(
+                start_time,
+                cancel,
+                operation_timeout_ns,
+                session,
+                auth_options,
+            ) catch blk: {
+                // we can still try to auth with a password if the user provided it, so we continue
+                break :blk;
+            };
+
+            if (try self.isAuthenticated(
+                start_time,
+                cancel,
+                operation_timeout_ns,
+                session,
+            )) {
+                return;
+            }
+        } else if (auth_options.private_key_path != null) {
             self.handlePrivateKeyAuth(
                 start_time,
                 cancel,
@@ -1153,6 +1173,100 @@ pub const Transport = struct {
                 @src(),
                 self.log,
                 "ssh2.Transport handlePrivateKeyAuth: failed private key authentication " ++
+                    "error code {d}",
+                .{rc},
+            );
+        }
+    }
+
+    fn handlePrivateKeyContentAuth(
+        self: *Transport,
+        start_time: std.Io.Timestamp,
+        cancel: ?*bool,
+        operation_timeout_ns: u64,
+        session: *c.LIBSSH2_SESSION,
+        auth_options: *auth.Options,
+    ) !void {
+        const private_key_passphrase_c = try self.allocator.dupeSentinel(
+            u8,
+            try auth_options.resolveAuthValue(
+                auth_options.private_key_passphrase orelse "",
+            ),
+            0,
+        );
+        defer self.allocator.free(private_key_passphrase_c);
+
+        const key_content = auth_options.private_key_content.?;
+
+        while (true) {
+            if (cancel != null and cancel.?.*) {
+                return errors.wrapCriticalError(
+                    errors.ScrapliError.Cancelled,
+                    @src(),
+                    self.log,
+                    "ssh2.Transport handlePrivateKeyContentAuth: operation cancelled",
+                    .{},
+                );
+            }
+
+            if (operation_timeout_ns != 0 and start_time.untilNow(self.io, .awake).nanoseconds > operation_timeout_ns) {
+                return errors.wrapCriticalError(
+                    errors.ScrapliError.TimeoutExceeded,
+                    @src(),
+                    self.log,
+                    "ssh2.Transport handlePrivateKeyContentAuth: operation timeout exceeded",
+                    .{},
+                );
+            }
+
+            const rc = c.libssh2_userauth_publickey_frommemory(
+                session,
+                @ptrCast(@constCast(auth_options.username.?)),
+                auth_options.username.?.len,
+                null, // public key data (derived by openssl backend)
+                0,
+                @ptrCast(@constCast(key_content)),
+                key_content.len,
+                private_key_passphrase_c.ptr,
+            );
+
+            if (rc == 0) {
+                break;
+            } else if (rc == c.LIBSSH2_ERROR_EAGAIN) {
+                try std.Io.Clock.Duration.sleep(
+                    .{
+                        .clock = .awake,
+                        .raw = .fromNanoseconds(default_eagain_delay_ns),
+                    },
+                    self.io,
+                );
+
+                continue;
+            }
+
+            var errmsg: [*c]u8 = null;
+            var errlen: c_int = 0;
+
+            // 0 => do not clear the error
+            const err: c_int = c.libssh2_session_last_error(
+                session,
+                &errmsg,
+                &errlen,
+                0,
+            );
+
+            if (errmsg != null and errlen > 0) {
+                const msg_slice = errmsg[0..@intCast(errlen)];
+                std.debug.print("libssh2 error: {} {s}\n", .{ err, msg_slice });
+            } else {
+                std.debug.print("libssh2 error: {} (no message)\n", .{err});
+            }
+
+            return errors.wrapCriticalError(
+                errors.ScrapliError.Transport,
+                @src(),
+                self.log,
+                "ssh2.Transport handlePrivateKeyContentAuth: failed private key authentication " ++
                     "error code {d}",
                 .{rc},
             );


### PR DESCRIPTION
## Description

This PR adds support for authenticating with a private key provided directly in memory, without requiring a key file on disk. 

### Relevant PRs
- https://github.com/scrapli/scrapligo/pull/235

## Purpose

Our integration manages credentials in memory and should never write private keys to disk. This change enables that workflow removing disk exposure for key material during auth.

## Testing

Built with locally updated compatible scrapligo v2 binaries and ensured consistent behavior within our implementation and test bench with in-memory auth keys.