### PR TITLE
fix: FFI crash when fetching sizes for incomplete operations

### DIFF
--- a/src/ffi-driver.zig
+++ b/src/ffi-driver.zig
@@ -808,6 +808,16 @@ pub const FfiDriver = struct {
             unreachable;
         }
 
+        if (!ret.?.done) {
+            return errors.wrapCriticalError(
+                errors.ScrapliError.Operation,
+                @src(),
+                self.getLogger(),
+                "operation not complete",
+                .{},
+            );
+        }
+
         if (remove) {
             // clean it up
             _ = self.operation_results.remove(operation_id);

--- a/src/ffi-root-cli.zig
+++ b/src/ffi-root-cli.zig
@@ -876,3 +876,51 @@ test "ffi: ls_cli_read_callback_should_execute null arguments" {
         ),
     );
 }
+
+test "ffi: ls_cli_fetch_operation_sizes incomplete operation" {
+    const d = try ffi_driver.FfiDriver.init(
+        std.testing.allocator,
+        std.testing.io,
+        "dummy",
+        .{
+            .definition = .{
+                .file = "src/tests/fixtures/platform_arista_eos_no_open_close_callbacks.yaml",
+            },
+        },
+    );
+    defer d.deinit();
+
+    var cancel = false;
+    const operation_id = try d.queueOperation(
+        ffi_operations.OperationOptions{
+            .id = 0,
+            .operation = .{
+                .cli = .{
+                    .close = .{
+                        .cancel = &cancel,
+                    },
+                },
+            },
+        },
+    );
+
+    var operation_count: u32 = 0;
+    var operation_input_size: usize = 0;
+    var operation_result_raw_size: usize = 0;
+    var operation_result_size: usize = 0;
+    var operation_failure_indicator_size: usize = 0;
+    var operation_error_size: usize = 0;
+
+    const ret = ls_cli_fetch_operation_sizes(
+        @ptrCast(d),
+        operation_id,
+        &operation_count,
+        &operation_input_size,
+        &operation_result_raw_size,
+        &operation_result_size,
+        &operation_failure_indicator_size,
+        &operation_error_size,
+    );
+
+    try std.testing.expectEqual(@intFromEnum(ffi_common.FfiResult.operation), ret);
+}


### PR DESCRIPTION
Disclaimer: I know absolutely nothing about Zig. So this PR is 100% vibecoded. If its totally b0rken, I hope it can act as a pointer to an error to be fixed properly by a skilled, human hand :) Let me know if you need any additional info.

Under heavy load on Linux, we discovered some panics in our Go application, so we unleashed AI on the stack traces and afterwards on the libscrapli code. The result is this PR. I've compiled the library and used it in the code with which I could trigger the panic, and it no longer panics with these changes.

The rest of the PR is from the AI

---

# Summary

- Prevent `ls_cli_fetch_operation_sizes` from panicking when called for an operation that has been queued but has not completed yet.
- Return the existing compatible FFI error code (`FfiResult.operation`) for incomplete operations instead of exposing the internal placeholder result.
- Add a regression test for fetching CLI operation sizes from an incomplete close operation.

# Root Cause

`FfiDriver.queueOperation` stores a placeholder operation result before the operation loop executes the requested operation:

```zig
.{ .done = false, .result = .{ .cli = null }, .err = null }
```

If a caller observes a stale readiness wakeup byte from a prior cancelled/timed-out operation, it can call `ls_cli_fetch_operation_sizes` for a newly queued close operation before that close operation has completed. The fetch path found the placeholder entry and treated it as complete, then force-unwrapped the null CLI result and panicked.

# Fix

`FfiDriver.dequeueOperation` now checks `done` before returning an operation result. If the operation exists but is not complete, it returns `ScrapliError.Operation`. Existing FFI fetch callers already convert that to `FfiResult.operation`, preserving the current FFI contract without adding a new result code.

# Test

Added `ffi: ls_cli_fetch_operation_sizes incomplete operation`, which queues a close operation and immediately calls `ls_cli_fetch_operation_sizes` before completion. The test verifies the function returns `FfiResult.operation` instead of panicking.

# Verification

```shell
zig build test
```

Result: `62 of 62 tests passed`.