### PR TITLE
fix: own ffi strings for async operations

### DIFF
--- a/src/cli-result.zig
+++ b/src/cli-result.zig
@@ -78,6 +78,10 @@ pub const Result = struct {
             self.allocator.free(result);
         }
 
+        for (self.inputs.items) |input| {
+            self.allocator.free(input);
+        }
+
         self.results_raw.deinit(self.allocator);
         self.results.deinit(self.allocator);
         self.inputs.deinit(self.allocator);
@@ -95,7 +99,11 @@ pub const Result = struct {
         },
     ) !void {
         try self.splits_ns.append(self.allocator, std.Io.Timestamp.now(self.io, .real).nanoseconds);
-        try self.inputs.append(self.allocator, data.input);
+        const owned_input = try self.allocator.dupe(u8, data.input);
+        self.inputs.append(self.allocator, owned_input) catch |err| {
+            self.allocator.free(owned_input);
+            return err;
+        };
         try self.results_raw.append(self.allocator, data.rets[0]);
 
         try self.results.append(self.allocator, data.rets[1]);

--- a/src/ffi-driver.zig
+++ b/src/ffi-driver.zig
@@ -329,6 +329,8 @@ pub const FfiDriver = struct {
                 continue;
             }
 
+            defer ffi_operations.deinitFfiOwnedOperationOptions(self.allocator, op.?);
+
             var ret_ok: ?*result.Result = null;
             var ret_err: ?anyerror = null;
 
@@ -491,6 +493,8 @@ pub const FfiDriver = struct {
             if (op == null) {
                 continue;
             }
+
+            defer ffi_operations.deinitFfiOwnedOperationOptions(self.allocator, op.?);
 
             var ret_ok: ?*result_netconf.Result = null;
             var ret_err: ?anyerror = null;

--- a/src/ffi-operations.zig
+++ b/src/ffi-operations.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const netconf_operation = @import("netconf-operation.zig");
 const operation = @import("cli-operation.zig");
 const result = @import("cli-result.zig");
@@ -20,6 +22,7 @@ pub const OperationResult = struct {
 /// cli or netconf operations.
 pub const OperationOptions = struct {
     id: u32,
+    ffi_owned: bool = false,
     operation: union(enum) {
         cli: union(enum) {
             open: operation.OpenOptions,
@@ -55,6 +58,108 @@ pub const OperationOptions = struct {
         },
     },
 };
+
+pub fn deinitFfiOwnedOperationOptions(
+    allocator: std.mem.Allocator,
+    options: OperationOptions,
+) void {
+    if (!options.ffi_owned) {
+        return;
+    }
+
+    switch (options.operation) {
+        .cli => |cli_op| switch (cli_op) {
+            .enter_mode => |o| allocator.free(o.requested_mode),
+            .send_input => |o| {
+                allocator.free(o.input);
+                allocator.free(o.requested_mode);
+            },
+            .send_inputs => |o| {
+                if (o._ffi_inputs) |ffi_inputs| {
+                    allocator.free(ffi_inputs);
+                }
+                allocator.free(o.requested_mode);
+            },
+            .send_prompted_input => |o| {
+                allocator.free(o.input);
+                if (o.prompt_exact) |prompt_exact| {
+                    allocator.free(prompt_exact);
+                }
+                if (o.prompt_pattern) |prompt_pattern| {
+                    allocator.free(prompt_pattern);
+                }
+                allocator.free(o.response);
+                allocator.free(o.requested_mode);
+                if (o.abort_input) |abort_input| {
+                    allocator.free(abort_input);
+                }
+            },
+            else => {},
+        },
+        .netconf => |netconf_op| switch (netconf_op) {
+            .raw_rpc => |o| {
+                allocator.free(o.payload);
+                if (o.base_namespace_prefix) |base_namespace_prefix| {
+                    allocator.free(base_namespace_prefix);
+                }
+                if (o._extra_namespaces_ffi) |extra_namespaces| {
+                    allocator.free(extra_namespaces);
+                }
+            },
+            .get_config => |o| {
+                if (o.filter) |filter| {
+                    allocator.free(filter);
+                }
+                if (o.filter_namespace_prefix) |filter_namespace_prefix| {
+                    allocator.free(filter_namespace_prefix);
+                }
+                if (o.filter_namespace) |filter_namespace| {
+                    allocator.free(filter_namespace);
+                }
+            },
+            .edit_config => |o| allocator.free(o.config),
+            .get => |o| {
+                if (o.filter) |filter| {
+                    allocator.free(filter);
+                }
+                if (o.filter_namespace_prefix) |filter_namespace_prefix| {
+                    allocator.free(filter_namespace_prefix);
+                }
+                if (o.filter_namespace) |filter_namespace| {
+                    allocator.free(filter_namespace);
+                }
+            },
+            .cancel_commit => |o| {
+                if (o.persist_id) |persist_id| {
+                    allocator.free(persist_id);
+                }
+            },
+            .get_schema => |o| {
+                allocator.free(o.identifier);
+                if (o.version) |version| {
+                    allocator.free(version);
+                }
+            },
+            .get_data => |o| {
+                if (o.filter) |filter| {
+                    allocator.free(filter);
+                }
+                if (o.filter_namespace_prefix) |filter_namespace_prefix| {
+                    allocator.free(filter_namespace_prefix);
+                }
+                if (o.filter_namespace) |filter_namespace| {
+                    allocator.free(filter_namespace);
+                }
+                if (o.origin_filters) |origin_filters| {
+                    allocator.free(origin_filters);
+                }
+            },
+            .edit_data => |o| allocator.free(o.edit_content),
+            .action => |o| allocator.free(o.action),
+            else => {},
+        },
+    }
+}
 
 /// CliOperationSizes holds operation sizes for an operation, returned from ffi driver to the ffi
 /// layer. Doesn't contain error size as that would be processed in a different branch before this

--- a/src/ffi-root-cli.zig
+++ b/src/ffi-root-cli.zig
@@ -2,6 +2,7 @@
 const std = @import("std");
 
 const cli = @import("cli.zig");
+const cli_operation = @import("cli-operation.zig");
 const errors = @import("errors.zig");
 const ffi_args_to_options = @import("ffi-args-to-cli-options.zig");
 const ffi_common = @import("ffi-common.zig");
@@ -10,6 +11,79 @@ const ffi_operations = @import("ffi-operations.zig");
 
 /// For forcing inclusion in the ffi-root.zig entrypoint we use for the ffi layer.
 pub const noop = true;
+
+fn dupeSlice(allocator: std.mem.Allocator, value: []const u8) ![]const u8 {
+    return try allocator.dupe(u8, value);
+}
+
+fn ffiOwnedEnterModeOptions(
+    allocator: std.mem.Allocator,
+    cancel: *bool,
+    requested_mode: [*c]const u8,
+) !cli_operation.EnterModeOptions {
+    return .{
+        .cancel = cancel,
+        .requested_mode = try dupeSlice(allocator, std.mem.span(requested_mode)),
+    };
+}
+
+fn ffiOwnedSendInputOptions(
+    allocator: std.mem.Allocator,
+    options: cli_operation.SendInputOptions,
+) !cli_operation.SendInputOptions {
+    var owned = options;
+    owned.input = try dupeSlice(allocator, options.input);
+    errdefer allocator.free(owned.input);
+    owned.requested_mode = try dupeSlice(allocator, options.requested_mode);
+
+    return owned;
+}
+
+fn ffiOwnedSendInputsOptions(
+    allocator: std.mem.Allocator,
+    options: cli_operation.SendInputsOptions,
+) !cli_operation.SendInputsOptions {
+    var owned = options;
+    if (options._ffi_inputs) |ffi_inputs| {
+        owned._ffi_inputs = try dupeSlice(allocator, ffi_inputs);
+    }
+    errdefer if (owned._ffi_inputs) |ffi_inputs| allocator.free(ffi_inputs);
+    owned.requested_mode = try dupeSlice(allocator, options.requested_mode);
+
+    return owned;
+}
+
+fn ffiOwnedSendPromptedInputOptions(
+    allocator: std.mem.Allocator,
+    options: cli_operation.SendPromptedInputOptions,
+) !cli_operation.SendPromptedInputOptions {
+    var owned = options;
+
+    owned.input = try dupeSlice(allocator, options.input);
+    errdefer allocator.free(owned.input);
+
+    if (options.prompt_exact) |prompt_exact| {
+        owned.prompt_exact = try dupeSlice(allocator, prompt_exact);
+    }
+    errdefer if (owned.prompt_exact) |prompt_exact| allocator.free(prompt_exact);
+
+    if (options.prompt_pattern) |prompt_pattern| {
+        owned.prompt_pattern = try dupeSlice(allocator, prompt_pattern);
+    }
+    errdefer if (owned.prompt_pattern) |prompt_pattern| allocator.free(prompt_pattern);
+
+    owned.response = try dupeSlice(allocator, options.response);
+    errdefer allocator.free(owned.response);
+
+    owned.requested_mode = try dupeSlice(allocator, options.requested_mode);
+    errdefer allocator.free(owned.requested_mode);
+
+    if (options.abort_input) |abort_input| {
+        owned.abort_input = try dupeSlice(allocator, abort_input);
+    }
+
+    return owned;
+}
 
 /// writes the ntc template platform from the driver's definition into the character slice at
 /// `ntc_template_platform` -- this slice should be pre populated w/ sufficient size (lets say
@@ -360,19 +434,26 @@ export fn ls_cli_enter_mode(
 
     const d: *ffi_driver.FfiDriver = @ptrCast(@alignCast(d_ptr));
 
-    const _operation_id = d.queueOperation(
-        ffi_operations.OperationOptions{
-            .id = 0,
-            .operation = .{
-                .cli = .{
-                    .enter_mode = .{
-                        .cancel = cancel,
-                        .requested_mode = std.mem.span(requested_mode),
-                    },
-                },
+    const options = ffiOwnedEnterModeOptions(
+        d.allocator,
+        cancel,
+        requested_mode,
+    ) catch |err| {
+        return ffi_common.toFfiResult(err);
+    };
+
+    const operation_options = ffi_operations.OperationOptions{
+        .id = 0,
+        .ffi_owned = true,
+        .operation = .{
+            .cli = .{
+                .enter_mode = options,
             },
         },
-    ) catch |err| {
+    };
+
+    const _operation_id = d.queueOperation(operation_options) catch |err| {
+        ffi_operations.deinitFfiOwnedOperationOptions(d.allocator, operation_options);
         // zlinter-disable-next-line no_swallow_error - returning status code for ffi ops
         errors.wrapCriticalError(
             errors.ScrapliError.Operation,
@@ -442,25 +523,29 @@ export fn ls_cli_send_input(
 
     const d: *ffi_driver.FfiDriver = @ptrCast(@alignCast(d_ptr));
 
-    const options = ffi_args_to_options.sendInputOptionsFromArgs(
+    const options = ffiOwnedSendInputOptions(d.allocator, ffi_args_to_options.sendInputOptionsFromArgs(
         cancel,
         input,
         requested_mode,
         input_handling,
         retain_input,
         retain_trailing_prompt,
-    );
+    )) catch |err| {
+        return ffi_common.toFfiResult(err);
+    };
 
-    const _operation_id = d.queueOperation(
-        ffi_operations.OperationOptions{
-            .id = 0,
-            .operation = .{
-                .cli = .{
-                    .send_input = options,
-                },
+    const operation_options = ffi_operations.OperationOptions{
+        .id = 0,
+        .ffi_owned = true,
+        .operation = .{
+            .cli = .{
+                .send_input = options,
             },
         },
-    ) catch |err| {
+    };
+
+    const _operation_id = d.queueOperation(operation_options) catch |err| {
+        ffi_operations.deinitFfiOwnedOperationOptions(d.allocator, operation_options);
         // zlinter-disable-next-line no_swallow_error - returning status code for ffi ops
         errors.wrapCriticalError(
             errors.ScrapliError.Operation,
@@ -496,7 +581,7 @@ export fn ls_cli_send_inputs(
 
     const d: *ffi_driver.FfiDriver = @ptrCast(@alignCast(d_ptr));
 
-    const options = ffi_args_to_options.sendInputsOptionsFromArgs(
+    const options = ffiOwnedSendInputsOptions(d.allocator, ffi_args_to_options.sendInputsOptionsFromArgs(
         cancel,
         inputs,
         requested_mode,
@@ -504,18 +589,22 @@ export fn ls_cli_send_inputs(
         retain_input,
         retain_trailing_prompt,
         stop_on_indicated_failure,
-    );
+    )) catch |err| {
+        return ffi_common.toFfiResult(err);
+    };
 
-    const _operation_id = d.queueOperation(
-        ffi_operations.OperationOptions{
-            .id = 0,
-            .operation = .{
-                .cli = .{
-                    .send_inputs = options,
-                },
+    const operation_options = ffi_operations.OperationOptions{
+        .id = 0,
+        .ffi_owned = true,
+        .operation = .{
+            .cli = .{
+                .send_inputs = options,
             },
         },
-    ) catch |err| {
+    };
+
+    const _operation_id = d.queueOperation(operation_options) catch |err| {
+        ffi_operations.deinitFfiOwnedOperationOptions(d.allocator, operation_options);
         // zlinter-disable-next-line no_swallow_error - returning status code for ffi ops
         errors.wrapCriticalError(
             errors.ScrapliError.Operation,
@@ -560,7 +649,7 @@ export fn ls_cli_send_prompted_input(
 
     const d: *ffi_driver.FfiDriver = @ptrCast(@alignCast(d_ptr));
 
-    const options = ffi_args_to_options.sendPromptedInputOptionsFromArgs(
+    const options = ffiOwnedSendPromptedInputOptions(d.allocator, ffi_args_to_options.sendPromptedInputOptionsFromArgs(
         cancel,
         input,
         prompt_exact,
@@ -571,18 +660,22 @@ export fn ls_cli_send_prompted_input(
         requested_mode,
         input_handling,
         retain_trailing_prompt,
-    );
+    )) catch |err| {
+        return ffi_common.toFfiResult(err);
+    };
 
-    const _operation_id = d.queueOperation(
-        ffi_operations.OperationOptions{
-            .id = 0,
-            .operation = .{
-                .cli = .{
-                    .send_prompted_input = options,
-                },
+    const operation_options = ffi_operations.OperationOptions{
+        .id = 0,
+        .ffi_owned = true,
+        .operation = .{
+            .cli = .{
+                .send_prompted_input = options,
             },
         },
-    ) catch |err| {
+    };
+
+    const _operation_id = d.queueOperation(operation_options) catch |err| {
+        ffi_operations.deinitFfiOwnedOperationOptions(d.allocator, operation_options);
         // zlinter-disable-next-line no_swallow_error - returning status code for ffi ops
         errors.wrapCriticalError(
             errors.ScrapliError.Operation,

--- a/src/ffi-root-netconf.zig
+++ b/src/ffi-root-netconf.zig
@@ -7,10 +7,133 @@ const ffi_args_to_options = @import("ffi-args-to-netconf-options.zig");
 const ffi_common = @import("ffi-common.zig");
 const ffi_driver = @import("ffi-driver.zig");
 const ffi_operations = @import("ffi-operations.zig");
+const netconf_operation = @import("netconf-operation.zig");
 const result = @import("netconf-result.zig");
 
 /// For forcing inclusion in the ffi-root.zig entrypoint we use for the ffi layer
 pub const noop = true;
+
+fn dupeSlice(allocator: std.mem.Allocator, value: []const u8) ![]const u8 {
+    return try allocator.dupe(u8, value);
+}
+
+fn dupeOptionalSlice(allocator: std.mem.Allocator, value: ?[]const u8) !?[]const u8 {
+    if (value) |v| {
+        return try dupeSlice(allocator, v);
+    }
+
+    return null;
+}
+
+fn ffiOwnedRawRpcOptions(
+    allocator: std.mem.Allocator,
+    options: netconf_operation.RawRpcOptions,
+) !netconf_operation.RawRpcOptions {
+    var owned = options;
+    owned.payload = try dupeSlice(allocator, options.payload);
+    errdefer allocator.free(owned.payload);
+    owned.base_namespace_prefix = try dupeOptionalSlice(allocator, options.base_namespace_prefix);
+    errdefer if (owned.base_namespace_prefix) |base_namespace_prefix| allocator.free(base_namespace_prefix);
+    owned._extra_namespaces_ffi = try dupeOptionalSlice(allocator, options._extra_namespaces_ffi);
+
+    return owned;
+}
+
+fn ffiOwnedGetConfigOptions(
+    allocator: std.mem.Allocator,
+    options: netconf_operation.GetConfigOptions,
+) !netconf_operation.GetConfigOptions {
+    var owned = options;
+    owned.filter = try dupeOptionalSlice(allocator, options.filter);
+    errdefer if (owned.filter) |filter| allocator.free(filter);
+    owned.filter_namespace_prefix = try dupeOptionalSlice(allocator, options.filter_namespace_prefix);
+    errdefer if (owned.filter_namespace_prefix) |prefix| allocator.free(prefix);
+    owned.filter_namespace = try dupeOptionalSlice(allocator, options.filter_namespace);
+
+    return owned;
+}
+
+fn ffiOwnedEditConfigOptions(
+    allocator: std.mem.Allocator,
+    options: netconf_operation.EditConfigOptions,
+) !netconf_operation.EditConfigOptions {
+    var owned = options;
+    owned.config = try dupeSlice(allocator, options.config);
+
+    return owned;
+}
+
+fn ffiOwnedGetOptions(
+    allocator: std.mem.Allocator,
+    options: netconf_operation.GetOptions,
+) !netconf_operation.GetOptions {
+    var owned = options;
+    owned.filter = try dupeOptionalSlice(allocator, options.filter);
+    errdefer if (owned.filter) |filter| allocator.free(filter);
+    owned.filter_namespace_prefix = try dupeOptionalSlice(allocator, options.filter_namespace_prefix);
+    errdefer if (owned.filter_namespace_prefix) |prefix| allocator.free(prefix);
+    owned.filter_namespace = try dupeOptionalSlice(allocator, options.filter_namespace);
+
+    return owned;
+}
+
+fn ffiOwnedCancelCommitOptions(
+    allocator: std.mem.Allocator,
+    options: netconf_operation.CancelCommitOptions,
+) !netconf_operation.CancelCommitOptions {
+    var owned = options;
+    owned.persist_id = try dupeOptionalSlice(allocator, options.persist_id);
+
+    return owned;
+}
+
+fn ffiOwnedGetSchemaOptions(
+    allocator: std.mem.Allocator,
+    options: netconf_operation.GetSchemaOptions,
+) !netconf_operation.GetSchemaOptions {
+    var owned = options;
+    owned.identifier = try dupeSlice(allocator, options.identifier);
+    errdefer allocator.free(owned.identifier);
+    owned.version = try dupeOptionalSlice(allocator, options.version);
+
+    return owned;
+}
+
+fn ffiOwnedGetDataOptions(
+    allocator: std.mem.Allocator,
+    options: netconf_operation.GetDataOptions,
+) !netconf_operation.GetDataOptions {
+    var owned = options;
+    owned.filter = try dupeOptionalSlice(allocator, options.filter);
+    errdefer if (owned.filter) |filter| allocator.free(filter);
+    owned.filter_namespace_prefix = try dupeOptionalSlice(allocator, options.filter_namespace_prefix);
+    errdefer if (owned.filter_namespace_prefix) |prefix| allocator.free(prefix);
+    owned.filter_namespace = try dupeOptionalSlice(allocator, options.filter_namespace);
+    errdefer if (owned.filter_namespace) |namespace| allocator.free(namespace);
+    owned.origin_filters = try dupeOptionalSlice(allocator, options.origin_filters);
+
+    return owned;
+}
+
+fn ffiOwnedEditDataOptions(
+    allocator: std.mem.Allocator,
+    options: netconf_operation.EditDataOptions,
+) !netconf_operation.EditDataOptions {
+    var owned = options;
+    owned.edit_content = try dupeSlice(allocator, options.edit_content);
+
+    return owned;
+}
+
+fn ffiOwnedActionOptions(
+    allocator: std.mem.Allocator,
+    options: netconf_operation.ActionOptions,
+) !netconf_operation.ActionOptions {
+    var owned = options;
+    owned.action = try dupeSlice(allocator, options.action);
+
+    return owned;
+}
 
 export fn ls_netconf_open(
     d_ptr: *ffi_common.LsDriver,
@@ -471,21 +594,27 @@ export fn ls_netconf_raw_rpc(
 
     const d: *ffi_driver.FfiDriver = @ptrCast(@alignCast(d_ptr));
 
-    const _operation_id = d.queueOperation(
-        ffi_operations.OperationOptions{
-            .id = 0,
-            .operation = .{
-                .netconf = .{
-                    .raw_rpc = ffi_args_to_options.rawRpcOptionsFromArgs(
-                        cancel,
-                        payload,
-                        base_namespace_prefix,
-                        extra_namespaces,
-                    ),
-                },
+    const options = ffiOwnedRawRpcOptions(d.allocator, ffi_args_to_options.rawRpcOptionsFromArgs(
+        cancel,
+        payload,
+        base_namespace_prefix,
+        extra_namespaces,
+    )) catch |err| {
+        return ffi_common.toFfiResult(err);
+    };
+
+    const operation_options = ffi_operations.OperationOptions{
+        .id = 0,
+        .ffi_owned = true,
+        .operation = .{
+            .netconf = .{
+                .raw_rpc = options,
             },
         },
-    ) catch |err| {
+    };
+
+    const _operation_id = d.queueOperation(operation_options) catch |err| {
+        ffi_operations.deinitFfiOwnedOperationOptions(d.allocator, operation_options);
         // zlinter-disable-next-line no_swallow_error - returning status code for ffi ops
         errors.wrapCriticalError(
             errors.ScrapliError.Operation,
@@ -526,7 +655,7 @@ export fn ls_netconf_get_config(
 
     const d: *ffi_driver.FfiDriver = @ptrCast(@alignCast(d_ptr));
 
-    const options = ffi_args_to_options.getConfigOptionsFromArgs(
+    const options = ffiOwnedGetConfigOptions(d.allocator, ffi_args_to_options.getConfigOptionsFromArgs(
         cancel,
         source,
         filter,
@@ -534,18 +663,22 @@ export fn ls_netconf_get_config(
         filter_namespace_prefix,
         filter_namespace,
         defaults_type,
-    );
+    )) catch |err| {
+        return ffi_common.toFfiResult(err);
+    };
 
-    const _operation_id = d.queueOperation(
-        ffi_operations.OperationOptions{
-            .id = 0,
-            .operation = .{
-                .netconf = .{
-                    .get_config = options,
-                },
+    const operation_options = ffi_operations.OperationOptions{
+        .id = 0,
+        .ffi_owned = true,
+        .operation = .{
+            .netconf = .{
+                .get_config = options,
             },
         },
-    ) catch |err| {
+    };
+
+    const _operation_id = d.queueOperation(operation_options) catch |err| {
+        ffi_operations.deinitFfiOwnedOperationOptions(d.allocator, operation_options);
         // zlinter-disable-next-line no_swallow_error - returning status code for ffi ops
         errors.wrapCriticalError(
             errors.ScrapliError.Operation,
@@ -584,25 +717,29 @@ export fn ls_netconf_edit_config(
 
     const d: *ffi_driver.FfiDriver = @ptrCast(@alignCast(d_ptr));
 
-    const options = ffi_args_to_options.editConfigOptionsFromArgs(
+    const options = ffiOwnedEditConfigOptions(d.allocator, ffi_args_to_options.editConfigOptionsFromArgs(
         cancel,
         config,
         target,
         default_operation,
         test_option,
         error_option,
-    );
+    )) catch |err| {
+        return ffi_common.toFfiResult(err);
+    };
 
-    const _operation_id = d.queueOperation(
-        ffi_operations.OperationOptions{
-            .id = 0,
-            .operation = .{
-                .netconf = .{
-                    .edit_config = options,
-                },
+    const operation_options = ffi_operations.OperationOptions{
+        .id = 0,
+        .ffi_owned = true,
+        .operation = .{
+            .netconf = .{
+                .edit_config = options,
             },
         },
-    ) catch |err| {
+    };
+
+    const _operation_id = d.queueOperation(operation_options) catch |err| {
+        ffi_operations.deinitFfiOwnedOperationOptions(d.allocator, operation_options);
         // zlinter-disable-next-line no_swallow_error - returning status code for ffi ops
         errors.wrapCriticalError(
             errors.ScrapliError.Operation,
@@ -819,25 +956,29 @@ export fn ls_netconf_get(
 
     const d: *ffi_driver.FfiDriver = @ptrCast(@alignCast(d_ptr));
 
-    const options = ffi_args_to_options.getOptionsFromArgs(
+    const options = ffiOwnedGetOptions(d.allocator, ffi_args_to_options.getOptionsFromArgs(
         cancel,
         filter,
         filter_type,
         filter_namespace_prefix,
         filter_namespace,
         defaults_type,
-    );
+    )) catch |err| {
+        return ffi_common.toFfiResult(err);
+    };
 
-    const _operation_id = d.queueOperation(
-        ffi_operations.OperationOptions{
-            .id = 0,
-            .operation = .{
-                .netconf = .{
-                    .get = options,
-                },
+    const operation_options = ffi_operations.OperationOptions{
+        .id = 0,
+        .ffi_owned = true,
+        .operation = .{
+            .netconf = .{
+                .get = options,
             },
         },
-    ) catch |err| {
+    };
+
+    const _operation_id = d.queueOperation(operation_options) catch |err| {
+        ffi_operations.deinitFfiOwnedOperationOptions(d.allocator, operation_options);
         // zlinter-disable-next-line no_swallow_error - returning status code for ffi ops
         errors.wrapCriticalError(
             errors.ScrapliError.Operation,
@@ -1013,19 +1154,25 @@ export fn ls_netconf_cancel_commit(
 
     const d: *ffi_driver.FfiDriver = @ptrCast(@alignCast(d_ptr));
 
-    const _operation_id = d.queueOperation(
-        ffi_operations.OperationOptions{
-            .id = 0,
-            .operation = .{
-                .netconf = .{
-                    .cancel_commit = ffi_args_to_options.cancelCommitOptionsFromArgs(
-                        cancel,
-                        persist_id,
-                    ),
-                },
+    const options = ffiOwnedCancelCommitOptions(d.allocator, ffi_args_to_options.cancelCommitOptionsFromArgs(
+        cancel,
+        persist_id,
+    )) catch |err| {
+        return ffi_common.toFfiResult(err);
+    };
+
+    const operation_options = ffi_operations.OperationOptions{
+        .id = 0,
+        .ffi_owned = true,
+        .operation = .{
+            .netconf = .{
+                .cancel_commit = options,
             },
         },
-    ) catch |err| {
+    };
+
+    const _operation_id = d.queueOperation(operation_options) catch |err| {
+        ffi_operations.deinitFfiOwnedOperationOptions(d.allocator, operation_options);
         // zlinter-disable-next-line no_swallow_error - returning status code for ffi ops
         errors.wrapCriticalError(
             errors.ScrapliError.Operation,
@@ -1102,21 +1249,27 @@ export fn ls_netconf_get_schema(
 
     const d: *ffi_driver.FfiDriver = @ptrCast(@alignCast(d_ptr));
 
-    const _operation_id = d.queueOperation(
-        ffi_operations.OperationOptions{
-            .id = 0,
-            .operation = .{
-                .netconf = .{
-                    .get_schema = ffi_args_to_options.getSchemaOptionsFromArgs(
-                        cancel,
-                        identifier,
-                        version,
-                        format,
-                    ),
-                },
+    const options = ffiOwnedGetSchemaOptions(d.allocator, ffi_args_to_options.getSchemaOptionsFromArgs(
+        cancel,
+        identifier,
+        version,
+        format,
+    )) catch |err| {
+        return ffi_common.toFfiResult(err);
+    };
+
+    const operation_options = ffi_operations.OperationOptions{
+        .id = 0,
+        .ffi_owned = true,
+        .operation = .{
+            .netconf = .{
+                .get_schema = options,
             },
         },
-    ) catch |err| {
+    };
+
+    const _operation_id = d.queueOperation(operation_options) catch |err| {
+        ffi_operations.deinitFfiOwnedOperationOptions(d.allocator, operation_options);
         // zlinter-disable-next-line no_swallow_error - returning status code for ffi ops
         errors.wrapCriticalError(
             errors.ScrapliError.Operation,
@@ -1163,28 +1316,34 @@ export fn ls_netconf_get_data(
 
     const d: *ffi_driver.FfiDriver = @ptrCast(@alignCast(d_ptr));
 
-    const _operation_id = d.queueOperation(
-        ffi_operations.OperationOptions{
-            .id = 0,
-            .operation = .{
-                .netconf = .{
-                    .get_data = ffi_args_to_options.getDataOptionsFromArgs(
-                        cancel,
-                        datastore,
-                        filter,
-                        filter_type,
-                        filter_namespace_prefix,
-                        filter_namespace,
-                        config_filter,
-                        origin_filters,
-                        max_depth,
-                        with_origin,
-                        defaults_type,
-                    ),
-                },
+    const options = ffiOwnedGetDataOptions(d.allocator, ffi_args_to_options.getDataOptionsFromArgs(
+        cancel,
+        datastore,
+        filter,
+        filter_type,
+        filter_namespace_prefix,
+        filter_namespace,
+        config_filter,
+        origin_filters,
+        max_depth,
+        with_origin,
+        defaults_type,
+    )) catch |err| {
+        return ffi_common.toFfiResult(err);
+    };
+
+    const operation_options = ffi_operations.OperationOptions{
+        .id = 0,
+        .ffi_owned = true,
+        .operation = .{
+            .netconf = .{
+                .get_data = options,
             },
         },
-    ) catch |err| {
+    };
+
+    const _operation_id = d.queueOperation(operation_options) catch |err| {
+        ffi_operations.deinitFfiOwnedOperationOptions(d.allocator, operation_options);
         // zlinter-disable-next-line no_swallow_error - returning status code for ffi ops
         errors.wrapCriticalError(
             errors.ScrapliError.Operation,
@@ -1219,21 +1378,27 @@ export fn ls_netconf_edit_data(
 
     const d: *ffi_driver.FfiDriver = @ptrCast(@alignCast(d_ptr));
 
-    const _operation_id = d.queueOperation(
-        ffi_operations.OperationOptions{
-            .id = 0,
-            .operation = .{
-                .netconf = .{
-                    .edit_data = ffi_args_to_options.editDataOptionsFromArgs(
-                        cancel,
-                        datastore,
-                        edit_content,
-                        default_operation,
-                    ),
-                },
+    const options = ffiOwnedEditDataOptions(d.allocator, ffi_args_to_options.editDataOptionsFromArgs(
+        cancel,
+        datastore,
+        edit_content,
+        default_operation,
+    )) catch |err| {
+        return ffi_common.toFfiResult(err);
+    };
+
+    const operation_options = ffi_operations.OperationOptions{
+        .id = 0,
+        .ffi_owned = true,
+        .operation = .{
+            .netconf = .{
+                .edit_data = options,
             },
         },
-    ) catch |err| {
+    };
+
+    const _operation_id = d.queueOperation(operation_options) catch |err| {
+        ffi_operations.deinitFfiOwnedOperationOptions(d.allocator, operation_options);
         // zlinter-disable-next-line no_swallow_error - returning status code for ffi ops
         errors.wrapCriticalError(
             errors.ScrapliError.Operation,
@@ -1263,19 +1428,25 @@ export fn ls_netconf_action(
 
     const d: *ffi_driver.FfiDriver = @ptrCast(@alignCast(d_ptr));
 
-    const _operation_id = d.queueOperation(
-        ffi_operations.OperationOptions{
-            .id = 0,
-            .operation = .{
-                .netconf = .{
-                    .action = .{
-                        .cancel = cancel,
-                        .action = std.mem.span(action),
-                    },
-                },
+    const options = ffiOwnedActionOptions(d.allocator, .{
+        .cancel = cancel,
+        .action = std.mem.span(action),
+    }) catch |err| {
+        return ffi_common.toFfiResult(err);
+    };
+
+    const operation_options = ffi_operations.OperationOptions{
+        .id = 0,
+        .ffi_owned = true,
+        .operation = .{
+            .netconf = .{
+                .action = options,
             },
         },
-    ) catch |err| {
+    };
+
+    const _operation_id = d.queueOperation(operation_options) catch |err| {
+        ffi_operations.deinitFfiOwnedOperationOptions(d.allocator, operation_options);
         // zlinter-disable-next-line no_swallow_error - returning status code for ffi ops
         errors.wrapCriticalError(
             errors.ScrapliError.Operation,


### PR DESCRIPTION
Encountered another panic when running many concurrent sessions. Again, this is created with help from an LLM as my Zig-skills are non-existent. Though this time around the changes are a bit more substantial - I have read the diff and have an understanding of what it does, but if it is doing it correctly I don't know. Let me know if you need further information.

The changes has been tested on the same load/code where we would trigger the panics. 

# Summary

Fixes FFI lifetime bugs for async CLI and NETCONF operations used by scrapligo.

FFI string arguments from purego/Go were queued as borrowed `std.mem.span` slices and consumed later by libscrapli operation threads. Under concurrent load, those temporary strings could be invalid or reused before the queued operation ran, leading to stale reads and crashes such as `@memcpy arguments alias` in `ls_cli_fetch_operation`.

# Changes

- Duplicate CLI FFI string inputs before queueing async operations.
- Duplicate NETCONF FFI string inputs before queueing async operations.
- Track FFI-owned queued operation strings with `ffi_owned` and free them after operation-thread consumption.
- Make CLI result inputs owned by `cli-result.Result` so fetch-time copies do not depend on caller or queued argument lifetimes.

# Verification

- `zig build test`
- Result: `62 of 62 tests passed`
