### PR TITLE
fix: ffi driver shutdown wakeup race

### DIFF
--- a/src/ffi-driver.zig
+++ b/src/ffi-driver.zig
@@ -169,11 +169,9 @@ pub const FfiDriver = struct {
 
     /// Deinitialize the FfiDriver and its underlying "real" driver.
     pub fn deinit(self: *FfiDriver) void {
-        self.operation_stop.store(true, std.lang.AtomicOrder.unordered);
-
-        // signal to the operation thread to iterate, it should then catch the stored stop condition
         // zlinter-disable-next-line no_swallow_error - standard lock should "never" fail
         self.operation_lock.lock(self.io) catch {};
+        self.operation_stop.store(true, std.lang.AtomicOrder.release);
         self.operation_condition.signal(self.io);
         self.operation_lock.unlock(self.io);
 
@@ -305,22 +303,26 @@ pub const FfiDriver = struct {
         self.operation_ready.store(true, std.lang.AtomicOrder.unordered);
 
         while (true) {
-            const stop = self.operation_stop.load(std.lang.AtomicOrder.acquire);
-            if (stop) {
-                break;
-            }
-
             self.operation_lock.lock(self.io) catch {
                 @panic("failed acquiring operation lock");
             };
 
-            if (self.operation_queue.count == 0) {
+            while (self.operation_queue.count == 0 and
+                !self.operation_stop.load(std.lang.AtomicOrder.acquire))
+            {
                 // nothing in the queue to process, wait for the signal
                 self.operation_condition.wait(self.io, &self.operation_lock) catch {
                     @panic(
                         "ffi-driver.FfiDriver: failed waiting for signal to unblock operation loop",
                     );
                 };
+            }
+
+            if (self.operation_stop.load(std.lang.AtomicOrder.acquire) and
+                self.operation_queue.count == 0)
+            {
+                self.operation_lock.unlock(self.io);
+                break;
             }
 
             const maybe_op = self.operation_queue.readItem();
@@ -478,22 +480,26 @@ pub const FfiDriver = struct {
         self.operation_ready.store(true, std.lang.AtomicOrder.unordered);
 
         while (true) {
-            const stop = self.operation_stop.load(std.lang.AtomicOrder.acquire);
-            if (stop) {
-                break;
-            }
-
             self.operation_lock.lock(self.io) catch {
                 @panic("ffi-driver.FfiDriver: failed acquiring operation lock");
             };
 
-            if (self.operation_queue.count == 0) {
+            while (self.operation_queue.count == 0 and
+                !self.operation_stop.load(std.lang.AtomicOrder.acquire))
+            {
                 // nothing in the queue to process, wait for the signal
                 self.operation_condition.wait(self.io, &self.operation_lock) catch {
                     @panic(
                         "ffi-driver.FfiDriver: failed waiting for signal to unblock operation loop",
                     );
                 };
+            }
+
+            if (self.operation_stop.load(std.lang.AtomicOrder.acquire) and
+                self.operation_queue.count == 0)
+            {
+                self.operation_lock.unlock(self.io);
+                break;
             }
 
             const maybe_op = self.operation_queue.readItem();


### PR DESCRIPTION
Back from vacation, I noticed one of our jobs using scrapligo/v2 had hung for 22 days, when it should have finished in just over one hour. Again I unleashed an LLM on the problem, and it came up with the following fix. I hope it is useful, let me know if you need any additional info.

There a second part to this which will come as a PR for scrapligo.

# Fix FFI Driver Shutdown Wakeup Race

## Summary

This fixes a lost-wakeup race in the FFI driver operation loop shutdown path.

`FfiDriver.deinit` can block forever while joining the operation thread if it signals the operation condition before the operation loop has entered `condition.wait`. In that case the signal is lost, the operation loop goes to sleep with `operation_stop=true`, and `deinit` waits forever in `operation_thread.join()`.

## Root Cause

The previous operation loop checked `operation_stop` before acquiring `operation_lock`, then waited when the queue was empty:

```zig
const stop = self.operation_stop.load(...);
if (stop) break;

self.operation_lock.lock(...);
if (self.operation_queue.count == 0) {
    self.operation_condition.wait(...);
}
```

That permits this race:

1. Operation thread completes an operation.
2. Operation thread checks `operation_stop == false`.
3. Another thread calls `ls_shared_free` / `FfiDriver.deinit`.
4. `deinit` sets `operation_stop = true` and signals the condition.
5. Operation thread then locks, sees an empty queue, and waits.
6. The signal was already lost, so the operation thread never wakes.
7. `deinit` blocks forever joining the operation thread.

## Fix

- `FfiDriver.deinit` now sets `operation_stop` and signals while holding `operation_lock`.
- `operationLoop` and `operationLoopNetconf` now wait using the correct predicate:
  - wait only while the operation queue is empty and shutdown has not been requested
  - after waking, exit if shutdown is requested and the queue is empty
- The actual operation execution still happens outside `operation_lock`.

## Validation

This fix was validated with a scrapligo load test that previously reproduced hangs in `ls_shared_free` while waiting for the operation thread to join.

After this change, the expected shutdown breadcrumbs were observed in debug builds:

```text
ffi_driver.operation_loop:wait:done stop=true queue_count=0
ffi_driver.operation_loop:stop_seen_after_wait
ffi_driver.operation_loop:exit
ffi_driver.deinit:operation_thread_join:done
```

The fix applies to both CLI and Netconf operation loops.

## Notes

This patch is intentionally limited to operation-loop shutdown correctness. It does not change public FFI signatures or operation execution behavior.
